### PR TITLE
add few syscalls to report dir as filename

### DIFF
--- a/lib/0xtools/proc.py
+++ b/lib/0xtools/proc.py
@@ -349,7 +349,10 @@ syscalls_with_fd_arg = set([
   , syscall_name_to_id['epoll_wait']        
   , syscall_name_to_id['ioctl']             
   , syscall_name_to_id['accept']            
-  , syscall_name_to_id['accept4']            
+  , syscall_name_to_id['accept4']         
+  , syscall_name_to_id['getdents']        
+  , syscall_name_to_id['getdents64']      
+  , syscall_name_to_id['unlinkat']        
 ])
 
 special_fds = { 0:'(stdin) ', 1:'(stdout)', 2:'(stderr)' }


### PR DESCRIPTION
getdents, unlinkat calls can be seen when working with directories with large number of files/inodes.
I'm not 100% sure it will work everywhere, and tested it on Ubuntu 20.04 only. It kinda works :)